### PR TITLE
remove redundant stringify

### DIFF
--- a/packages/addon/src/types.ts
+++ b/packages/addon/src/types.ts
@@ -1,4 +1,4 @@
-export type Cookie = Record<string, unknown>;
+export type Cookie = Record<string, string>;
 
 export type CookieParameter = {
   cookie?: Cookie;

--- a/packages/addon/src/utils.ts
+++ b/packages/addon/src/utils.ts
@@ -1,11 +1,15 @@
 import { Cookie } from './types';
 
-export function setCookie(name: string, value: unknown) {
-  document.cookie = `${name}=${JSON.stringify(value)}`;
+export function setCookie(name: string, value: string) {
+  if (typeof value !== 'string') {
+    document.cookie = `${name}=${JSON.stringify(value)};`;
+  } else {
+    document.cookie = `${name}=${value};`;
+  }
 }
 
 export function setCookies(cookie: Cookie) {
-  const entries: [string, unknown][] = Object.keys(cookie).map((name) => [
+  const entries: [string, string][] = Object.keys(cookie).map((name) => [
     name,
     cookie[name],
   ]);

--- a/packages/addon/src/utils.ts
+++ b/packages/addon/src/utils.ts
@@ -4,7 +4,8 @@ export function setCookie(name: string, value: string) {
   if (typeof value !== 'string') {
     document.cookie = `${name}=${JSON.stringify(value)};`;
   } else {
-    document.cookie = `${name}=${value};`;
+    const encodedValue = encodeURIComponent(value);
+    document.cookie = `${name}=${encodedValue};`;
   }
 }
 


### PR DESCRIPTION
cookie values should always be strings, not objects. running JSON.stringify wraps the values in redundant quotes.